### PR TITLE
added a better approach to hide a column on create

### DIFF
--- a/app/Filament/Resources/CustomerResource.php
+++ b/app/Filament/Resources/CustomerResource.php
@@ -37,16 +37,16 @@ class CustomerResource extends Resource
                     ->schema([
                         Placeholder::make('user_id')
                             ->label('Owner')
-                            ->content(fn (Customer $customer): ?string => $customer?->owner?->name)
-                            ->hidden(fn (?Customer $customer) => $customer->id === null),
+                            ->content(fn(Customer $customer): ?string => $customer?->owner?->name)
+                            ->hiddenOn('create'),
                         Placeholder::make('created_at')
                             ->label('Created at')
-                            ->content(fn (Customer $customer): ?string => $customer->created_at?->diffForHumans())
-                            ->hidden(fn (?Customer $customer) => $customer->id === null),
+                            ->content(fn(Customer $customer): ?string => $customer->created_at?->diffForHumans())
+                            ->hiddenOn('create'),
                         Placeholder::make('updated_at')
                             ->label('Last upated')
-                            ->content(fn (Customer $customer): ?string => $customer->updated_at?->diffForHumans())
-                            ->hidden(fn (?Customer $customer) => $customer->id === null),
+                            ->content(fn(Customer $customer): ?string => $customer->updated_at?->diffForHumans())
+                            ->hiddenOn('create'),
                     ])
                     ->columnSpan(1),
             ])->columns(3);
@@ -60,7 +60,7 @@ class CustomerResource extends Resource
                 TextColumn::make('email'),
                 TextColumn::make('phone_number'),
                 TextColumn::make('owner.name')
-                    ->hidden(fn (Customer $customer): bool => $customer->user_id !== auth()->user()->id),
+                    ->hidden(fn(Customer $customer): bool => $customer->user_id !== auth()->user()->id),
                 TextColumn::make('created_at'),
                 TextColumn::make('updated_at'),
             ])


### PR DESCRIPTION
A better approach on hiding a column on `create/edit` pages [hiding-components-based-on-the-current-operation](https://filamentphp.com/docs/3.x/panels/resources/getting-started#hiding-components-based-on-the-current-operation)