### PR TITLE
Add owner at the time of create with trait in resource and header action in table of relation manager

### DIFF
--- a/app/Actions/OwnedCreateAction.php
+++ b/app/Actions/OwnedCreateAction.php
@@ -1,0 +1,17 @@
+<?php
+namespace App\Actions;
+
+use Filament\Tables\Actions\CreateAction;
+
+class OwnedCreateAction
+{
+    public static function make()
+    {
+        return CreateAction::make()
+            ->mutateFormDataUsing(function (array $data): array {
+                $data['owner_id'] = auth()->id();
+                return $data;
+            });
+    }
+
+}

--- a/app/Actions/OwnedCreateAction.php
+++ b/app/Actions/OwnedCreateAction.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace App\Actions;
 
 use Filament\Tables\Actions\CreateAction;
@@ -10,8 +11,8 @@ class OwnedCreateAction
         return CreateAction::make()
             ->mutateFormDataUsing(function (array $data): array {
                 $data['owner_id'] = auth()->id();
+
                 return $data;
             });
     }
-
 }

--- a/app/Filament/Resources/ContactResource/RelationManagers/DealsRelationManager.php
+++ b/app/Filament/Resources/ContactResource/RelationManagers/DealsRelationManager.php
@@ -2,6 +2,7 @@
 
 namespace App\Filament\Resources\ContactResource\RelationManagers;
 
+use App\Actions\OwnedCreateAction;
 use App\Filament\Resources\DealResource;
 use Filament\Forms\Form;
 use Filament\Resources\RelationManagers\RelationManager;
@@ -32,12 +33,7 @@ class DealsRelationManager extends RelationManager
                 //
             ])
             ->headerActions([
-                Tables\Actions\CreateAction::make()
-                    ->mutateFormDataUsing(function (array $data) {
-                        $data['owner_id'] = auth()->user()->id;
-
-                        return $data;
-                    }),
+                OwnedCreateAction::make(),
             ])
             ->actions([
                 Tables\Actions\EditAction::make(),

--- a/app/Filament/Resources/DealResource/Pages/CreateDeal.php
+++ b/app/Filament/Resources/DealResource/Pages/CreateDeal.php
@@ -3,16 +3,12 @@
 namespace App\Filament\Resources\DealResource\Pages;
 
 use App\Filament\Resources\DealResource;
+use App\Traits\OwnedDataMutation;
 use Filament\Resources\Pages\CreateRecord;
 
 class CreateDeal extends CreateRecord
 {
+    use OwnedDataMutation;
+
     protected static string $resource = DealResource::class;
-
-    protected function mutateFormDataBeforeCreate(array $data): array
-    {
-        $data['owner_id'] = auth()->user()->id;
-
-        return $data;
-    }
 }

--- a/app/Traits/OwnedDataMutation.php
+++ b/app/Traits/OwnedDataMutation.php
@@ -7,6 +7,7 @@ trait OwnedDataMutation
     protected function mutateFormDataBeforeCreate(array $data): array
     {
         $data['owner_id'] = auth()->user()->id;
+
         return $data;
     }
 }

--- a/app/Traits/OwnedDataMutation.php
+++ b/app/Traits/OwnedDataMutation.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace App\Traits;
+
+trait OwnedDataMutation
+{
+    protected function mutateFormDataBeforeCreate(array $data): array
+    {
+        $data['owner_id'] = auth()->user()->id;
+        return $data;
+    }
+}


### PR DESCRIPTION
Added a trait to add at the time of creation in **Resource**

```
trait OwnedDataMutation
{
    protected function mutateFormDataBeforeCreate(array $data): array
    {
        $data['owner_id'] = auth()->user()->id;
        return $data;
    }
}
```

### Usage
```
class CreateDeal extends CreateRecord
{
    use OwnedDataMutation;

    protected static string $resource = DealResource::class;
}
```

and 

A custom action class to add owner at time of create from table header **OwnedCreateAction** 
```
class OwnedCreateAction
{
    public static function make()
    {
        return CreateAction::make()
            ->mutateFormDataUsing(function (array $data): array {
                $data['owner_id'] = auth()->id();
                return $data;
            });
    }

}
```

### Usage
```
->headerActions([
    OwnedCreateAction::make(),
])
```